### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ You can apply many different capabilities of St. Jude Cloud to your research, su
 
 ## Datasets
 
-The following projects currently distribute their data through St. Jude Cloud. Click [here](./glossary.md#data-access-unit) for more information about the projects listed below.
+The following projects currently distribute their data through St. Jude Cloud. Click [here](./citing-stjude-cloud.md#dataset-reference-table) for more information about the projects listed below.
 
 * Pediatric Cancer Genome Project (PCGP)
 * St. Jude Lifetime (SJLIFE)


### PR DESCRIPTION
When moving the schedule 1 descriptions, I missed updating the link from the Welcome page to more info about the datasets. Here, it's updated to link to the dataset reference table on the citation page.