### PR TITLE
Update Broken External Links

### DIFF
--- a/docs/guides/data/creating-a-cloud-app.md
+++ b/docs/guides/data/creating-a-cloud-app.md
@@ -35,7 +35,7 @@ For this tutorial I have requested the PCGP dataset, and once my access request 
 
 | Tool       | Download                                                             | Website                                                               | Version  |
 | ---------- | -------------------------------------------------------------------- | --------------------------------------------------------------------- | -------- |
-| dx-toolkit | [Source](https://wiki.dnanexus.com/downloads)                        | [DNAnexus](https://www.dnanexus.com/)                                 | v0.276.0 |
+| dx-toolkit | [Source](https://documentation.dnanexus.com/downloads)               | [DNAnexus](https://www.dnanexus.com/)                                 | v0.276.0 |
 | FastQC     | [Source](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/) | [Babraham Bioinformatics](https://www.bioinformatics.babraham.ac.uk/) | v0.11.8  |
 
 </center>
@@ -112,7 +112,7 @@ $ Choose an instance type for your app [mem1_ssd1_x4]: azure:mem1_ssd1_x4
 ```
 
 !!! Tip
-    Although our app doesn't need any Internet access in this example, it may be required for your project. Also be sure to check what instance type you will need in the [API Specifications](https://wiki.dnanexus.com/api-specification-v1.0.0/instance-types).
+    Although our app doesn't need any Internet access in this example, it may be required for your project. Also be sure to check what instance type you will need in the [API Specifications](https://documentation.dnanexus.com/developer/api/running-analyses/instance-types).
 
 The FastQC executable supports a variety of file formats (BAM, SAM, FastQ, etc.), and outputs a HTML report and a zip file that contains all the graphs and data. We will use that knowledge to write the input and output parameters for our application. We can also specify other parameters such as the timeout policy, programming language, and instance type. For more information, refer to the [IO and Run Specification](https://documentation.dnanexus.com/developer/api/running-analyses/io-and-run-specifications) guide.
 

--- a/docs/guides/tools/chipseq.md
+++ b/docs/guides/tools/chipseq.md
@@ -219,7 +219,7 @@ and the job logs can be accessed by clicking around the sub-items.
 ![](../../images/guides/tools/chipseq/job-detailed-view.gif) 
 
 !!! tip 
-    Power users can view the [DNAnexus Job Monitoring Tutorial](https://wiki.dnanexus.com/UI/Jobs) and the [DNAnexus Command Line Tutorial for Job Monitoring](https://wiki.dnanexus.com/Command-Line-Client/Monitoring-Executions) for advanced capabilities for monitoring jobs.
+    Power users can refer to the [DNAnexus Monitoring Executions Documentation](https://documentation.dnanexus.com/user/running-apps-and-workflows/monitoring-executions) for advanced capabilities for monitoring jobs.
 
 ### Interactive visualizations
 

--- a/docs/guides/tools/neoepitope.md
+++ b/docs/guides/tools/neoepitope.md
@@ -223,7 +223,7 @@ and even viewing the job logs can accessed by clicking around the sub-items.
 ![](../../images/guides/tools/neoepitope/job-detailed-view.gif) 
 
 !!! tip 
-    Power users can view the [DNAnexus Job Monitoring Tutorial](https://wiki.dnanexus.com/UI/Jobs) and the [DNAnexus Command Line Tutorial for Job Monitoring](https://wiki.dnanexus.com/Command-Line-Client/Monitoring-Executions) for advanced capabilities for monitoring jobs.
+    Power users can refer to the [DNAnexus Monitoring Executions Documentation](https://documentation.dnanexus.com/user/running-apps-and-workflows/monitoring-executions) for advanced capabilities for monitoring jobs.
 
 ## Analysis of results
 

--- a/docs/guides/tools/pecan-pie.md
+++ b/docs/guides/tools/pecan-pie.md
@@ -236,7 +236,7 @@ underlying analysis pipelines independently on the
 [DNAnexus](https://www.dnanexus.com) platform. If you just want to use
 the Pecan PIE website you can safely ignore this section of the
 documentation. We assume familiarity with the DNAnexus platform. If you aren't
-familiar with this, DNAnexus' [quickstart guide](https://wiki.dnanexus.com/Command-Line-Client/Quickstart) is a
+familiar with this, DNAnexus' [quickstart guide](https://documentation.dnanexus.com/getting-started/tutorials/cli-quickstart) is a
 great place to start.
 
 !!! warning
@@ -279,7 +279,7 @@ There are two methods of running pipelines on DNAnexus:
 All input files must be uploaded onto the DNAnexus platform. When
 specifying files for input you can use either the DNAnexus fie IDs (e.g.
 `file-FBgvp680gz1bGQ5p8yZKz69g`), or the filenames if they are unique. For
-an idea of how to upload files to DNAnexus, see [this guide](https://wiki.dnanexus.com/Command-Line-Client/Upload%20and%20Download%20Files#Uploading).
+an idea of how to upload files to DNAnexus, see [this guide](https://documentation.dnanexus.com/user/objects/uploading-and-downloading-files/small-sets-of-files/uploading-using-dx#uploading-files).
 
 ### Step 1: Running VEP+
 

--- a/docs/guides/tools/rapid-rnaseq.md
+++ b/docs/guides/tools/rapid-rnaseq.md
@@ -203,7 +203,7 @@ and even viewing the job logs can accessed by clicking around the sub-items.
 ![](../../images/guides/tools/rapid-rnaseq/job-detailed-view.gif) 
 
 !!! tip 
-    Power users can view the [DNAnexus Job Monitoring Tutorial](https://wiki.dnanexus.com/UI/Jobs) and the [DNAnexus Command Line Tutorial for Job Monitoring](https://wiki.dnanexus.com/Command-Line-Client/Monitoring-Executions) for advanced capabilities for monitoring jobs.
+    Power users can refer to the [DNAnexus Monitoring Executions Documentation](https://documentation.dnanexus.com/user/running-apps-and-workflows/monitoring-executions) for advanced capabilities for monitoring jobs.
 
 ## Analysis of results
 

--- a/docs/guides/tools/warden.md
+++ b/docs/guides/tools/warden.md
@@ -288,7 +288,7 @@ Other information, such as time, cost of individual steps in the pipeline,
 and even viewing the job logs can accessed by clicking around the sub-items.
 
 !!! tip 
-    Power users can view the [DNAnexus Job Monitoring Tutorial](https://wiki.dnanexus.com/UI/Jobs) and the [DNAnexus Command Line Tutorial for Job Monitoring](https://wiki.dnanexus.com/Command-Line-Client/Monitoring-Executions) for advanced capabilities for monitoring jobs.
+    Power users can refer to the [DNAnexus Monitoring Executions Documentation](https://documentation.dnanexus.com/user/running-apps-and-workflows/monitoring-executions) for advanced capabilities for monitoring jobs.
 
 ## Analysis of results
 


### PR DESCRIPTION
Replace references linking to the old `wiki.dnanexus.com` documentation with the updated `documentation.dnanexus.com` equivalent.