### PR TITLE
genomics-platform/analyzing-data: Unhide cis-X workflow guide

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ nav:
               - WARDEN Differential Expression Analysis: guides/genomics-platform/analyzing-data/warden.md
               - Mutational Signatures: guides/genomics-platform/analyzing-data/mutational-signatures.md
               - SequencErr: guides/genomics-platform/analyzing-data/sequencerr.md
-              # Cis-X: guides/genomics-platform/analyzing-data/cis-x.md
+              - cis-X: guides/genomics-platform/analyzing-data/cis-x.md
               # M2A: guides/genomics-platform/analyzing-data/m2a.md
               # XenoCP: guides/genomics-platform/analyzing-data/xeno-cp.md
               # RNA Indel: guides/genomics-platform/analyzing-data/rna-indel.md


### PR DESCRIPTION
This reenables the entry for cis-X in the table of contents.