### PR TITLE
Replace Miniconda setup action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,10 @@ jobs:
   deploy:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
         with:
           submodules: recursive
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2.0.1
         with:
           auto-update-conda: true
           environment-file: environment.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash -l {0}
         run: bash bin/ci-build.sh
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3.7.3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./site


### PR DESCRIPTION
This PR replaces the `goanpeca/setup-miniconda` action with `conda-incubator/setup-miniconda`. The failing builds were caused by an update to the [GitHub Actions environment files](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) that addressed a recent security vulnerability. 