### PR TITLE
docs: add FAQ for expression data facet. Clean up some markdown and text

### DIFF
--- a/content/3.pecan/1.overview/2.methods-and-data.md
+++ b/content/3.pecan/1.overview/2.methods-and-data.md
@@ -18,7 +18,7 @@ Variant data is sourced from published studies from St. Jude Children's Research
 A user can access associated studies by clicking `Associated Study` where applicable.
 
 ::callout{icon="i-heroicons-light-bulb" color="blue"}
-**Tip**  
+**Tip**
 Gene lists are not curated.
 Access specific `Associated Study` links for subsets of data, such as the Medulloblastoma example [here](https://pecan.stjude.cloud/variants/oncoprint/BT%7CMB).
 ::
@@ -45,7 +45,7 @@ The 20 most frequently observed genes are shown by default in each pathway; othe
 | CNV GAIN       | Copy number gain.                                                                                                                                       |
 
 ::callout{icon="i-heroicons-exclamation-circle" color="orange"}
-**Warning**  
+**Warning**
 Silent mutations and untranslated region (UTR) variants are excluded in some prevalence views due to their lack of effect.
 Only pathogenic or likely pathogenic variants are included in assessing mutational prevalence for pan-cancer genes.
 CNV classes are not displayed in ProteinPaint.
@@ -143,7 +143,7 @@ COSMIC SBS signatures (v3.3) were identified using SigProfilerExtractor (v1.1.20
 Sample data from G4K, PCGP, Clinical Pilot, and Real-Time Clinical Genomics (RTCG) were used for mutational signature detection.
 
 ::callout{icon="i-heroicons-light-bulb" color="blue"}
-**Tip**  
+**Tip**
 Example data from 790 tumor samples can be found in [Figure 5 of McLeod et al](https://cancerdiscovery.aacrjournals.org/content/11/5/1082.long).
 ::
 
@@ -153,20 +153,20 @@ Example data from 790 tumor samples can be found in [Figure 5 of McLeod et al](h
 
 ### t-SNE Methods
 
-[RAPID RNA-Seq workflow](https://university.stjude.cloud/docs/genomics-platform/workflow-guides/rapid-rnaseq/) was used to generate RNA-seq expression count data and visualized via ProteinPaint's scatter plot.
+St. Jude Cloud's [Rapid RNA-Seq workflow](https://university.stjude.cloud/docs/genomics-platform/workflow-guides/rapid-rnaseq/) was used to generate RNA-seq expression counts data and visualized on PeCan's expression t-SNE plot.
 
 ### t-SNE Data
 
 Sample data comes from G4K, PCGP, Clinical Pilot, and Real-Time Clinical Genomics studies.
 
 ::callout{icon="i-heroicons-light-bulb" color="blue"}
-**Tip**  
+**Tip**
 Example data from 1,574 RNA-Seq samples can be accessed [here](https://viz.stjude.cloud/st-jude-childrens-research-hospital/visualization/pediatric-blood-solid-and-brain-tumor-rna-seq-t-sne-plot-1574-samples~24).
 ::
 
 ### Gene Expression Methods
 
-DESeq2's Median of Ratios^1 was applied to ~5500 tumor samples for gene expression analysis.
+DESeq2's Median of Ratios was applied to ~5500 tumor samples for gene expression analysis.
 We advocate for this methodology over TPM/CPM due to its stability and resistance to outliers.
 
 #### Key Benefits
@@ -192,6 +192,6 @@ Histological images are provided by the [COMET Blue Sky Initiative](https://www.
 A large subset of COMET slides are pending publication.
 
 ::callout{icon="i-heroicons-exclamation-circle" color="green"}
-**Interested in collaborating?**  
+**Interested in collaborating?**
 Reach out to us at [support@stjude.cloud](mailto:support@stjude.cloud).
 ::

--- a/content/3.pecan/2.data-facets/3.expression.md
+++ b/content/3.pecan/2.data-facets/3.expression.md
@@ -12,9 +12,8 @@ This facet comprises three tabs, allowing users to explore the expression landsc
 
 ![tsne sample view](/img/pecan/data-facets/expression/expression-t-sne-sample-view.png)
 
-**Figure 1: t-SNE for Blood, Brain, and Solid Samples.**
+**Figure 1: t-SNE for Blood, Brain, and Solid Tumor Samples.**
 Mouse over data points to access metadata details for each sample.
-Visualization powered by D3.
 
 ![gene violin plots](/img/pecan/data-facets/expression/expression-gene-violin-plots.png)
 
@@ -23,10 +22,11 @@ Gene expression violin plots for each sample, filtered by the gene of interest.
 Visualization powered by Plotly.
 
 ::callout{icon="i-heroicons-document-text-solid" color="blue"}
-**Note**  
+**Note**
 
 - All samples use the hg38 reference genome.
 - Full metadata can be accessed through our [manifest](https://platform.stjude.cloud/api/v1/manifest).
+- Gene Expression values are log10 transformed to normalize outlier values while representing the expression data.
 ::
 
 ---
@@ -45,7 +45,7 @@ Visualization powered by Plotly.
 ![tsne features overview](/img/pecan/data-facets/expression/expression-t-sne-features-overview.gif)
 
 ::callout{icon="i-heroicons-exclamation-circle" color="orange"}
-**Warning**  
+**Warning**
 Filtering by the sunburst will auto-populate the Root and Subtype filters.
 These can be manually edited but will not update the sunburst.
 ::
@@ -61,7 +61,7 @@ These can be manually edited but will not update the sunburst.
 | **Median Sort**      | Sort the gene expression sandboxes by median expression across or within individual groups.  |
 | **Outlier Toggle**   | Toggle off data points to keep outliers intact for the cohort currently being filtered.      |
 
-For data normalization details, refer to our [Methods and Data](/pecan/overview/methods-and-data) page.
+For data normalization details, refer to our [Methods and Data](/pecan/overview/methods-and-data#gene-expression-methods) page.
 
 ![violin plots](/img/pecan/data-facets/expression/expression-violin-plots.gif)
 
@@ -71,7 +71,7 @@ For data normalization details, refer to our [Methods and Data](/pecan/overview/
 
 Users can overlay gene expression on the t-SNE plot by selecting genes of interest.
 Count data is normalized using Median of Ratios (MoR).
-More details can be found on the [Methods and Data](/pecan/overview/methods-and-data) page.
+More details can be found on the [Methods and Data](/pecan/overview/methods-and-data#gene-expression-methods) page.
 
 ![gene expression toggle](/img/pecan/data-facets/expression/expression-gene-expression-toggle.gif)
 
@@ -114,15 +114,25 @@ The data matrix displays all filtered data with sortable headers for easier expl
 | **Preservative**               | Multi-select dropdown for sample preservative types. |
 
 ::callout{icon="i-heroicons-exclamation-circle" color="orange"}
-**Warning**  
+**Warning**
 Some fields may have a "Not Available" option for samples where the data wasn't recorded (e.g., Race, Ethnicity, Sex).
 ::
 
 ::callout{icon="i-heroicons-light-bulb" color="blue"}
-**Tip**  
+**Tip**
 For a subset of this data, refer to [Figure 4f of McLeod et al.](https://cancerdiscovery.aacrjournals.org/content/11/5/1082.long)
 ::
 
 ---
 
-To see how the data was calculated and normalized, visit our [Methods and Data](/pecan/overview/methods-and-data) page.
+## Frequently Asked Questions
+
+### Why was the expression data transformed using log10?
+
+During development, we observed that displaying raw Median of Ratios values resulted in outliers disproportionately dominating the visualizations, making it difficult to distinguish differences among most samples.
+To address this, we evaluated both log2 and log10 transformations of the data on a selection of important representative genes. The log10 transformation offered a slightly more effective and visually interpretable presentation of the data.
+As a result, we adopted the log10 transformation for all Median of Ratios values displayed in the interface.
+
+---
+
+To see how the data was calculated and normalized, visit our [Methods and Data](/pecan/overview/methods-and-data#expression) page.


### PR DESCRIPTION
This PR adds a FAQ section to the expression data facet documentation to explain the choice of log10 transforming the MoR counts in PeCan.

Additionally, some content was updated to reflect the current PeCan implementation. And some whitespaces were deleted.