### PR TITLE
revise: clarify that variants come from a DB

### DIFF
--- a/content/3.genomics-platform/2.about-our-data/2.file-formats-and-sequencing-information.md
+++ b/content/3.genomics-platform/2.about-our-data/2.file-formats-and-sequencing-information.md
@@ -48,7 +48,7 @@ These somatic VCF files contain hg38 coordinate SNV/Indel variant calls generate
       This includes samples belonging to the Clinical Pilot cohort study and some of the PCGP cohort studies.
     * For currently unpublished patient tumor samples, we filtered variants based on metrics derived from the in-house post-processing pipeline and the input of analysts [(see below)](#sample-variant-validation-and-filtering).
       This includes the patient samples in the G4K study, along with some unpublished PCGP and Clinical Pilot cohort study samples.
-9. Variants were converted from our in-house formats to VCF format.
+9. Variants were exported from a database and converted to VCF format.
 10. Variant coordinates were lifted over to GRCh38_no_alt using [Picard][picard] `LiftoverVcf`.
 11. Variants were normalized using [`vt normalize`][vt].
 12. Variants were annotated using [VEP v100][vep] and the `--everything` flag.


### PR DESCRIPTION
As discussed in RTCG meeting, we should clarify that variants are source from a database