### PR TITLE
revise: Add PanALL to Glossary

### DIFF
--- a/content/3.genomics-platform/1.getting-started/6.glossary.md
+++ b/content/3.genomics-platform/1.getting-started/6.glossary.md
@@ -9,7 +9,7 @@ A St. Jude Cloud **Data Access Unit (DAU)** is a grouping of data that typically
 Each DAU has its own governing body of researchers, the [Data Access Committee](#data-access-committee), who preside over the data and who may grant or deny access.
 Each Data Access Committee has its own protocols for approving access to their DAU.
 Please [contact us](mailto:support@stjude.cloud) if you have questions about committee approval protocols.
-We currently have 5 DAUs: Pediatric Cancer Genome Project (PCGP), St. Jude Lifetime Cohort Study (SJLIFE), Genomes for Kids (G4K) and Clinical Genomics, Sickle Cell Genome Project (SGP), and Childhood Cancer Survivor Study (CCSS).
+We currently have 6 DAUs: Pediatric Cancer Genome Project (PCGP), St. Jude Lifetime Cohort Study (SJLIFE), Genomes for Kids (G4K) and Clinical Genomics, Sickle Cell Genome Project (SGP), Childhood Cancer Survivor Study (CCSS), and Pan-Acute Lymphoblastic Leukemia (PanALL).
 For a brief description of each DAU see the Studies page.
 For a more detailed description please see the respective [Schedule 1(s)](/overview/citing-stjude-cloud#dataset-reference-table).
 


### PR DESCRIPTION
We added PanALL to the list of DAUs, numbering "6" rather than "5" DAUs.